### PR TITLE
Fix(client/Modal): styles added to components ModalReclamo and ModalS…

### DIFF
--- a/client/src/components/modalReclamo/modalReclamo.jsx
+++ b/client/src/components/modalReclamo/modalReclamo.jsx
@@ -77,13 +77,13 @@ export default function ModalReclamo(props) {
     const body=(
         <div >
             <div align="center">
-                <h2>Inicia tu reclamo</h2>
+                <h2 className="CommentTitle">Inicia tu reclamo</h2>
             </div>
-            <label>Email: {props.userEmail}</label>
+            <label className="CommentTitle">Email: {props.userEmail}</label>
             <br/>
-            <label>Orden: {props.id}</label>
+            <label className="CommentTitle">Orden: {props.id}</label>
             <br/>
-            <label>Motivos: </label> 
+            <label className="CommentTitle">Motivos: </label> 
              <select  name="motivos"id="motivos"  defaultValue="" 
               onChange={(e)=>handleOnChange(e)}
              >
@@ -94,15 +94,17 @@ export default function ModalReclamo(props) {
             <option>Problema con la suma de puntos</option>
             <option>Otros motivos</option>
             </select>
-
+            <br/>
+            <br/>
+            <div align="center">
             <h3 className="CommentTitle">Agrega un comentario</h3>
-            <textarea name="coment" type="text" maxlength="300" className="commentTextarea" value={coments} onChange={(e)=>setComents(e.target.value)}/>
+            <textarea  name="coment" type="text" maxlength="300" className="commentTextarea" value={coments} onChange={(e)=>setComents(e.target.value)}/>
             <p className="commentLength">{coments.length}/300</p>
-            
-            <div align="right">
+            </div>
+            <div align="center">
 
-            <Button className={styles.bttn} disabled = {handleDisabled()} onClick={(e) => handleSubmit(e)}>Enviar</Button>
-            <Button onClick={()=>props.closeModal() }>Cancelar</Button>
+            <button className={styles.button} disabled = {handleDisabled()} onClick={(e) => handleSubmit(e)}>Enviar</button>
+            <button className={styles.button} onClick={()=>props.closeModal() }>Cancelar</button>
 
             </div>
 

--- a/client/src/components/modalShippingAddress/modalShippingAddress.jsx
+++ b/client/src/components/modalShippingAddress/modalShippingAddress.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Modal, TextField, Button} from "@material-ui/core";
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-
+import styles from "./modalShippingAddress.module.css";
 
 
 
@@ -34,19 +34,19 @@ export default function ModalShippingAddress(props) {
         <div >
             
             <div align="center">
-                <h2>Confirma tu direccion de envio</h2>
+                <h2 className={styles.h2}>Confirma tu dirección de envío</h2>
             </div>
             <br/>
             <br/>
-            <label>Nombre y Apellido: {props.user}</label>
+            <label className={styles.label}>Nombre y Apellido: {props.user}</label>
             <br/>
             <br/>
             <TextField fullWidth label="Direccion:" id="fullWidth" value={props.address} onChange={handleOnChange}></TextField>
             <div align="center">
             <br/>
             <br/>
-            <Button disabled = {!props.address? true : false}onClick={()=>props.handlecheckout()}>Continuar</Button>
-            <Button onClick={()=>props.closeModal() } variant="contained">Cancelar</Button>
+            <button className={styles.button} disabled = {!props.address? true : false}onClick={()=>props.handlecheckout()}>Continuar</button>
+            <button className={styles.button} onClick={()=>props.closeModal() } variant="contained">Cancelar</button>
             </div>
 
         </div>

--- a/client/src/components/modalShippingAddress/modalShippingAddress.module.css
+++ b/client/src/components/modalShippingAddress/modalShippingAddress.module.css
@@ -23,3 +23,11 @@
     .disable{
         background-color: gray;
     }
+
+.h2 {
+    color: rgb(82, 82, 82);
+}
+.label {
+    color: rgb(82, 82, 82);
+    
+}

--- a/client/src/components/userOrders/orderList.jsx
+++ b/client/src/components/userOrders/orderList.jsx
@@ -90,7 +90,7 @@ function Row(props) {
         </TableCell> 
        
         <TableCell> 
-        {props.status !== "Completada" && props.status !== "Cancelada" && props.status !== "Rechazada" && props.status !== "Pendiente" ? 
+        {props.status === "En camino" ? 
         <Tooltip title="Confirmar entrega" placement="top-start">
         <IconButton size="large" aria-label="show 4 new mails" color="inherit" name="Completada"
           onClick={()=> dispatch(updateOrderStatus({id:props.id,estado:"Completada"})) }   >


### PR DESCRIPTION
Se agregaron estilos a los ModalReclamo y ModalShippingAddress:

- Texto color gris
- Botones mismo estilos que todos los de la pagina
- Se agrego tilde
- Se centro
- Boton de confirmar entrega solo disponible cuando el estado es "En camino"
- Boton de cancelar una compra solo disponible mientras el estado esta en "Aprobado"
- Boton de iniciar un reclamo disponible siempre

<img width="2091" alt="Screen Shot 2022-11-07 at 22 38 15" src="https://user-images.githubusercontent.com/97701179/200453599-f5ce92c5-85c2-4aa5-9853-5385bbb7bfde.png">

<img width="2091" alt="Screen Shot 2022-11-07 at 22 40 51" src="https://user-images.githubusercontent.com/97701179/200453696-26af86fa-cfb4-4cf4-91e1-697199d1d145.png">
